### PR TITLE
WS-4662: fix menu radius

### DIFF
--- a/paragon/css/core/custom-media-breakpoints.css
+++ b/paragon/css/core/custom-media-breakpoints.css
@@ -1,6 +1,6 @@
 /**
  * IMPORTANT: This file is the result of assembling design tokens
  * Do not edit directly
- * Generated on Wed, 22 May 2024 19:01:45 GMT
+ * Generated on Thu, 23 May 2024 13:50:34 GMT
  */
 

--- a/paragon/css/core/variables.css
+++ b/paragon/css/core/variables.css
@@ -1,7 +1,7 @@
 /**
  * IMPORTANT: This file is the result of assembling design tokens
  * Do not edit directly
- * Generated on Wed, 22 May 2024 19:01:45 GMT
+ * Generated on Thu, 23 May 2024 13:50:34 GMT
  */
 
 :root {
@@ -65,27 +65,27 @@
   --pgn-typography-display-weight-3: 700;
   --pgn-typography-display-weight-2: 700;
   --pgn-typography-display-weight-1: 700;
-  --pgn-typography-headings-font-weight: 700;
-  --pgn-typography-btn-font-weight: 500;
   --pgn-typography-badge-font-weight: 400;
   --pgn-typography-badge-font-size: 0.75rem;
+  --pgn-typography-headings-font-weight: 700;
+  --pgn-typography-btn-font-weight: 500;
   --pgn-spacing-spacer-base: 1rem;
   --pgn-spacing-spacer-0: 0;
   --pgn-spacing-btn-focus-gap: 2px;
   --pgn-size-popover-border-width: 0px;
   --pgn-size-nav-pills-border-radius: 0;
   --pgn-size-image-thumbnail-border-radius: 0;
+  --pgn-size-dropdown-border-width: 0;
   --pgn-size-input-btn-border-width: 1px;
   --pgn-size-form-input-radius-border-sm: 0;
   --pgn-size-form-input-radius-border-lg: 0;
   --pgn-size-form-input-radius-border-base: 0;
-  --pgn-size-dropdown-border-width: 0;
   --pgn-size-btn-border-radius-sm: 100px;
   --pgn-size-btn-border-radius-lg: 100px;
   --pgn-size-btn-border-radius-base: 100px;
   --pgn-size-border-radius-sm: .375rem;
   --pgn-size-border-radius-lg: .375rem;
-  --pgn-size-border-radius-base: 6.25rem;
+  --pgn-size-border-radius-base: .375rem;
   --pgn-typography-font-line-height-1: 1rem;
   --pgn-typography-font-weight-base: 400;
   --pgn-typography-font-size-lg: calc(1.125rem * 1.25);
@@ -103,12 +103,9 @@
   --pgn-spacing-spacer-1: calc(1rem * .25);
   --pgn-spacing-caret-vertical-align: calc(.3em * .67);
   --pgn-spacing-caret-base: calc(.3em * 1);
-  --pgn-size-btn-focus-border-radius-sm: 100px;
-  --pgn-size-btn-focus-border-radius-base: calc(100px + calc(2px + 2px));
   --pgn-spacing-grid-gutter-width: calc(1rem * 4);
   --pgn-spacing-dropdown-padding-y-item: calc(1rem * .75);
   --pgn-spacing-dropdown-padding-y-base: calc(1rem * .5);
   --pgn-spacing-card-spacer-y: 1rem;
   --pgn-spacing-card-spacer-x: calc(1rem * 1.5);
-  --pgn-size-btn-focus-border-radius-lg: calc(100px + calc(2px + 2px));
 }

--- a/paragon/css/themes/light/variables.css
+++ b/paragon/css/themes/light/variables.css
@@ -1,7 +1,7 @@
 /**
  * IMPORTANT: This file is the result of assembling design tokens
  * Do not edit directly
- * Generated on Wed, 22 May 2024 19:01:46 GMT
+ * Generated on Thu, 23 May 2024 13:50:35 GMT
  */
 
 :root {
@@ -100,13 +100,13 @@
   --pgn-color-btn-disabled-bg-outline-info: #000000FF;
   --pgn-color-btn-disabled-bg-outline-dark: #000000FF;
   --pgn-color-btn-disabled-bg-outline-danger: #000000FF;
-  --pgn-other-btn-disabled-opacity: .3;
   --pgn-elevation-box-shadow-level-4: 0px 8px 48px 0px rgba(0,0,0,0.15), 0px 20px 40px 0px rgba(0,0,0,0.15);
   --pgn-elevation-box-shadow-level-3: 0px 8px 20px 0px rgba(0,0,0,0.15), 0px 10px 20px 0px rgba(0,0,0,0.15);
   --pgn-elevation-box-shadow-level-2: 0px 4px 10px 0px rgba(0,0,0,0.15), 0px 8px 16px 0px rgba(0,0,0,0.15);
   --pgn-elevation-box-shadow-level-1: 0px 2px 8px 0px rgba(0,0,0,0.15), 0px 2px 4px 0px rgba(0,0,0,0.15);
   --pgn-elevation-image-thumbnail-box-shadow: none;
   --pgn-elevation-form-input-base: none;
+  --pgn-other-btn-disabled-opacity: .3;
   --pgn-transition-btn: none;
   --pgn-typography-input-btn-line-height-sm: 1.4286;
   --pgn-typography-input-btn-line-height-base: 1.3333;
@@ -135,6 +135,7 @@
   --pgn-color-tooltip-bg-base: #F0F2F2FF;
   --pgn-color-tooltip-light: #F0F2F2FF;
   --pgn-color-pagination-text-base: #F0F2F2FF;
+  --pgn-color-badge-bg-info: #00BBF9FF;
   --pgn-color-link-hover: #003A5BFF;
   --pgn-color-link-base: #00688DFF;
   --pgn-color-headings-base: #1F453DFF;
@@ -178,7 +179,6 @@
   --pgn-color-btn-bg-danger: #8B0B02FF;
   --pgn-color-btn-bg-outline-brand: #FFFFFFFF;
   --pgn-color-btn-bg-brand: #A93405FF;
-  --pgn-color-badge-bg-info: #00BBF9FF;
   --pgn-color-theme-active-gray: #171A1DFF;
   --pgn-color-theme-active-dark: #040A08FF;
   --pgn-color-theme-active-light: #201F1DFF;

--- a/tokens/src/core/alias/size.json
+++ b/tokens/src/core/alias/size.json
@@ -2,7 +2,7 @@
   "size": {
     "border": {
       "radius": {
-        "base": { "value": "6.25rem" },
+        "base": { "value": ".375rem" },
         "lg": { "value": ".375rem" },
         "sm": { "value": ".375rem" }
       }


### PR DESCRIPTION
The base border radius affected the radius of the dropdown menus, not just buttons. Buttons still have a border radius of 100px with this change as they pull from `$btn-border-radius` which overrides the core value.

### Before

![Screenshot 2024-05-20 at 2 06 33 PM](https://github.com/edx/elm-theme/assets/10442143/e31c3e8c-a113-4bc4-bf9e-1b8e3a9aac6e)

### After

![Screenshot 2024-05-20 at 1 35 16 PM](https://github.com/edx/elm-theme/assets/10442143/d6b10735-2949-4e0c-b213-cc25d26e2b35)
