### PR TITLE
feat: primary button variant override for Modal footer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "UNLICENSED",
       "devDependencies": {
-        "@openedx/paragon": "^23.10.1",
+        "@openedx/paragon": "^23.12.2",
         "nodemon": "^3.1.4"
       }
     },
@@ -550,9 +550,9 @@
       }
     },
     "node_modules/@openedx/paragon": {
-      "version": "23.10.1",
-      "resolved": "https://registry.npmjs.org/@openedx/paragon/-/paragon-23.10.1.tgz",
-      "integrity": "sha512-URThgJ3DdDoq2lnMOTVJHGtWkX27asIIxyfRPwjKuyqHeC+5Dv8u0KJL0+fpOZOUEsTcd23nO0I57uIDFwZAKQ==",
+      "version": "23.12.2",
+      "resolved": "https://registry.npmjs.org/@openedx/paragon/-/paragon-23.12.2.tgz",
+      "integrity": "sha512-NBHmKEVkq4bzBnwL/KgUMCQCJ74A4PIr5c4TLdx/UrQ+uegZT7s+IuuaAAHkyaMnpqcHranNvweEBXRIzDsYyA==",
       "dev": true,
       "license": "Apache-2.0",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "paragon:help": "paragon help"
   },
   "devDependencies": {
-    "@openedx/paragon": "^23.10.1",
+    "@openedx/paragon": "^23.12.2",
     "nodemon": "^3.1.4"
   }
 }

--- a/paragon/css/themes/light/overrides/component-button-variants.css
+++ b/paragon/css/themes/light/overrides/component-button-variants.css
@@ -2,10 +2,31 @@
  * Do not edit directly, this file was auto-generated.
  */
 
-// Alert
+/* Alert actions */
 
 .pgn__alert-message-wrapper .pgn__alert-actions .btn-primary,
 .pgn__alert-message-wrapper-stacked .pgn__alert-actions .btn-primary {
+  --pgn-btn-color: var(--pgn-color-btn-text-brand);
+  --pgn-btn-bg: var(--pgn-color-btn-bg-brand);
+  --pgn-btn-border-color: var(--pgn-color-btn-border-brand);
+  --pgn-btn-hover-color: var(--pgn-color-btn-hover-text-brand);
+  --pgn-btn-hover-bg: var(--pgn-color-btn-hover-bg-brand);
+  --pgn-btn-hover-border-color: var(--pgn-color-btn-hover-border-brand);
+  --pgn-btn-disabled-color: var(--pgn-color-btn-disabled-text-brand);
+  --pgn-btn-disabled-bg: var(--pgn-color-btn-disabled-bg-brand);
+  --pgn-btn-disabled-border-color: var(--pgn-color-btn-disabled-border-brand);
+  --pgn-btn-active-color: var(--pgn-color-btn-active-text-brand);
+  --pgn-btn-active-bg: var(--pgn-color-btn-active-bg-brand);
+  --pgn-btn-active-border-color: var(--pgn-color-btn-active-border-brand);
+  --pgn-btn-focus-outline-color: var(--pgn-color-btn-focus-outline-brand);
+  --pgn-btn-focus-color: var(--pgn-color-btn-focus-text-brand);
+  --pgn-btn-focus-border-color: var(--pgn-color-btn-focus-border-brand);
+  --pgn-btn-focus-bg: var(--pgn-color-btn-focus-bg-brand);
+}
+
+/* Modal footer */
+
+.pgn__modal .pgn__modal-footer .btn-primary {
   --pgn-btn-color: var(--pgn-color-btn-text-brand);
   --pgn-btn-bg: var(--pgn-color-btn-bg-brand);
   --pgn-btn-border-color: var(--pgn-color-btn-border-brand);

--- a/tokens/src/themes/light/components/Modal.json
+++ b/tokens/src/themes/light/components/Modal.json
@@ -1,4 +1,17 @@
 {
+  "color": {
+    "modal": {
+      "footer": {
+        "overrides": {
+          "button": {
+            "variants": {
+              "primary": "brand"
+            }
+          }
+        }
+      }
+    }
+  },
   "elevation": {
     "modal": {
       "content": {


### PR DESCRIPTION
The Paragon Elm Theme Figma calls for using the brand button variant within the modal footer across the modal variants (e.g., `ModalDialog`, `StandardModal`, `AlertModal`, etc.). This PR maps the original variant `primary` to be rendered as if `variant="brand"` were passed instead.