### PR TITLE
fix: styles for inverse-brand and inverse-outline-brand button variants

### DIFF
--- a/paragon/css/themes/light/variables.css
+++ b/paragon/css/themes/light/variables.css
@@ -187,6 +187,7 @@
   --pgn-color-badge-bg-info: var(--pgn-color-accent-a);
   --pgn-color-btn-text-primary: var(--pgn-color-white);
   --pgn-color-btn-bg-outline-brand: var(--pgn-color-white);
+  --pgn-color-btn-bg-inverse-outline-brand: var(--pgn-color-white);
   --pgn-color-btn-bg-danger: var(--pgn-color-danger-600);
   --pgn-color-btn-bg-outline-danger: var(--pgn-color-white);
   --pgn-color-btn-bg-dark: var(--pgn-color-dark-600);
@@ -201,6 +202,7 @@
   --pgn-color-btn-bg-warning: var(--pgn-color-warning-600);
   --pgn-color-btn-bg-outline-warning: var(--pgn-color-white);
   --pgn-color-btn-hover-text-outline-brand: var(--pgn-color-white);
+  --pgn-color-btn-hover-text-inverse-outline-brand: var(--pgn-color-white);
   --pgn-color-btn-hover-text-outline-danger: #FFFFFFFF;
   --pgn-color-btn-hover-text-outline-dark: #FFFFFFFF;
   --pgn-color-btn-hover-text-outline-info: #FFFFFFFF;
@@ -218,6 +220,7 @@
   --pgn-color-btn-hover-bg-outline-warning: var(--pgn-color-warning-600);
   --pgn-color-btn-active-text-brand: var(--pgn-color-white);
   --pgn-color-btn-active-text-inverse-brand: var(--pgn-color-white);
+  --pgn-color-btn-active-text-inverse-outline-brand: var(--pgn-color-white);
   --pgn-color-btn-active-text-primary: var(--pgn-color-white);
   --pgn-color-btn-active-bg-outline-brand: var(--pgn-color-white);
   --pgn-color-btn-active-bg-outline-primary: var(--pgn-color-white);
@@ -225,6 +228,7 @@
   --pgn-color-btn-focus-text-brand: var(--pgn-color-white);
   --pgn-color-btn-focus-text-primary: var(--pgn-color-white);
   --pgn-color-btn-focus-border-inverse-brand: var(--pgn-color-btn-border-inverse-brand);
+  --pgn-color-btn-focus-bg-inverse-outline-brand: var(--pgn-color-white);
   --pgn-color-btn-focus-bg-tertiary: var(--pgn-color-white);
   --pgn-color-btn-disabled-bg-brand: var(--pgn-color-brand-100);
   --pgn-color-btn-disabled-bg-outline-brand: var(--pgn-color-white);
@@ -354,6 +358,7 @@
   --pgn-color-theme-default-light: var(--pgn-color-light-500); /** Theme-specific light default color. */
   --pgn-color-theme-default-dark: var(--pgn-color-dark-500); /** Theme-specific dark default color. */
   --pgn-color-theme-default-gray: var(--pgn-color-gray-500); /** Theme-specific gray default color. */
+  --pgn-color-btn-text-inverse-outline-brand: var(--pgn-color-brand-500);
   --pgn-color-btn-text-danger: #FFFFFFFF;
   --pgn-color-btn-text-outline-danger: var(--pgn-color-btn-bg-danger);
   --pgn-color-btn-text-dark: #FFFFFFFF;
@@ -369,6 +374,7 @@
   --pgn-color-btn-bg-inverse-brand: var(--pgn-color-brand-500);
   --pgn-color-btn-bg-light: var(--pgn-color-light-500);
   --pgn-color-btn-bg-primary: var(--pgn-color-primary-500);
+  --pgn-color-btn-border-inverse-outline-brand: var(--pgn-color-brand-500);
   --pgn-color-btn-border-danger: var(--pgn-color-btn-bg-danger);
   --pgn-color-btn-border-outline-danger: var(--pgn-color-btn-bg-danger);
   --pgn-color-btn-border-dark: var(--pgn-color-btn-bg-dark);
@@ -383,6 +389,7 @@
   --pgn-color-btn-hover-text-inverse-brand: var(--pgn-color-brand-500);
   --pgn-color-btn-hover-text-outline-light: #454545FF;
   --pgn-color-btn-hover-bg-outline-brand: var(--pgn-color-brand-500);
+  --pgn-color-btn-hover-bg-inverse-outline-brand: var(--pgn-color-brand-500);
   --pgn-color-btn-hover-bg-danger: var(--pgn-color-theme-hover-danger);
   --pgn-color-btn-hover-bg-dark: var(--pgn-color-theme-hover-dark);
   --pgn-color-btn-hover-bg-info: var(--pgn-color-theme-hover-info);
@@ -403,6 +410,7 @@
   --pgn-color-btn-active-text-outline-primary: var(--pgn-color-primary-500);
   --pgn-color-btn-active-text-tertiary: var(--pgn-color-primary-500);
   --pgn-color-btn-active-bg-brand: var(--pgn-color-brand-500);
+  --pgn-color-btn-active-bg-inverse-outline-brand: var(--pgn-color-brand-500);
   --pgn-color-btn-active-bg-inverse-brand: var(--pgn-color-brand-500);
   --pgn-color-btn-active-bg-danger: var(--pgn-color-theme-active-danger);
   --pgn-color-btn-active-bg-outline-danger: var(--pgn-color-btn-bg-danger);
@@ -515,6 +523,7 @@
   --pgn-color-btn-hover-bg-secondary: var(--pgn-color-secondary-400);
   --pgn-color-btn-hover-bg-outline-secondary: var(--pgn-color-secondary-600);
   --pgn-color-btn-hover-border-outline-brand: var(--pgn-color-btn-hover-bg-outline-brand);
+  --pgn-color-btn-hover-border-inverse-outline-brand: var(--pgn-color-btn-hover-bg-outline-brand);
   --pgn-color-btn-hover-border-danger: var(--pgn-color-btn-hover-bg-danger);
   --pgn-color-btn-hover-border-dark: var(--pgn-color-btn-hover-bg-dark);
   --pgn-color-btn-hover-border-info: var(--pgn-color-btn-hover-bg-info);

--- a/paragon/css/themes/light/variables.css
+++ b/paragon/css/themes/light/variables.css
@@ -30,6 +30,7 @@
   --pgn-elevation-box-shadow-level-3: 0px 8px 20px 0px rgba(0,0,0,0.15), 0px 10px 20px 0px rgba(0,0,0,0.15); /** Basic box shadow of level 3. */
   --pgn-elevation-box-shadow-level-4: 0px 8px 48px 0px rgba(0,0,0,0.15), 0px 20px 40px 0px rgba(0,0,0,0.15); /** Basic box shadow of level 4. */
   --pgn-other-btn-disabled-opacity: .3;
+  --pgn-color-btn-border-inverse-brand: #00000000;
   --pgn-color-btn-focus-outline-tertiary: #00000000;
   --pgn-color-popover-header-bg: #00000000;
   --pgn-color-white: #FFFFFFFF; /** White color. */
@@ -208,6 +209,7 @@
   --pgn-color-btn-hover-text-outline-success: #FFFFFFFF;
   --pgn-color-btn-hover-text-outline-warning: #393939FF;
   --pgn-color-btn-hover-bg-brand: var(--pgn-color-white);
+  --pgn-color-btn-hover-bg-inverse-brand: #ECECECFF;
   --pgn-color-btn-hover-bg-outline-danger: var(--pgn-color-danger-600);
   --pgn-color-btn-hover-bg-outline-dark: var(--pgn-color-dark-600);
   --pgn-color-btn-hover-bg-outline-info: var(--pgn-color-info-600);
@@ -215,15 +217,18 @@
   --pgn-color-btn-hover-bg-outline-success: var(--pgn-color-success-600);
   --pgn-color-btn-hover-bg-outline-warning: var(--pgn-color-warning-600);
   --pgn-color-btn-active-text-brand: var(--pgn-color-white);
+  --pgn-color-btn-active-text-inverse-brand: var(--pgn-color-white);
   --pgn-color-btn-active-text-primary: var(--pgn-color-white);
   --pgn-color-btn-active-bg-outline-brand: var(--pgn-color-white);
   --pgn-color-btn-active-bg-outline-primary: var(--pgn-color-white);
   --pgn-color-btn-active-bg-tertiary: var(--pgn-color-white);
   --pgn-color-btn-focus-text-brand: var(--pgn-color-white);
   --pgn-color-btn-focus-text-primary: var(--pgn-color-white);
+  --pgn-color-btn-focus-border-inverse-brand: var(--pgn-color-btn-border-inverse-brand);
   --pgn-color-btn-focus-bg-tertiary: var(--pgn-color-white);
   --pgn-color-btn-disabled-bg-brand: var(--pgn-color-brand-100);
   --pgn-color-btn-disabled-bg-outline-brand: var(--pgn-color-white);
+  --pgn-color-btn-disabled-bg-inverse-brand: var(--pgn-color-brand-100);
   --pgn-color-form-input-bg-base: var(--pgn-color-white);
   --pgn-color-form-input-focus-bg: var(--pgn-color-white);
   --pgn-color-form-feedback-valid: var(--pgn-color-success-base);
@@ -361,6 +366,7 @@
   --pgn-color-btn-text-warning: #393939FF;
   --pgn-color-btn-text-outline-warning: var(--pgn-color-btn-bg-warning);
   --pgn-color-btn-bg-brand: var(--pgn-color-brand-500);
+  --pgn-color-btn-bg-inverse-brand: var(--pgn-color-brand-500);
   --pgn-color-btn-bg-light: var(--pgn-color-light-500);
   --pgn-color-btn-bg-primary: var(--pgn-color-primary-500);
   --pgn-color-btn-border-danger: var(--pgn-color-btn-bg-danger);
@@ -374,6 +380,7 @@
   --pgn-color-btn-border-warning: var(--pgn-color-btn-bg-warning);
   --pgn-color-btn-border-outline-warning: var(--pgn-color-btn-bg-warning);
   --pgn-color-btn-hover-text-brand: var(--pgn-color-brand-500);
+  --pgn-color-btn-hover-text-inverse-brand: var(--pgn-color-brand-500);
   --pgn-color-btn-hover-text-outline-light: #454545FF;
   --pgn-color-btn-hover-bg-outline-brand: var(--pgn-color-brand-500);
   --pgn-color-btn-hover-bg-danger: var(--pgn-color-theme-hover-danger);
@@ -385,6 +392,7 @@
   --pgn-color-btn-hover-bg-success: var(--pgn-color-theme-hover-success);
   --pgn-color-btn-hover-bg-warning: var(--pgn-color-theme-hover-warning);
   --pgn-color-btn-hover-border-brand: var(--pgn-color-brand-500);
+  --pgn-color-btn-hover-border-inverse-brand: var(--pgn-color-brand-500);
   --pgn-color-btn-hover-border-outline-danger: var(--pgn-color-btn-hover-bg-outline-danger);
   --pgn-color-btn-hover-border-outline-dark: var(--pgn-color-btn-hover-bg-outline-dark);
   --pgn-color-btn-hover-border-outline-info: var(--pgn-color-btn-hover-bg-outline-info);
@@ -395,6 +403,7 @@
   --pgn-color-btn-active-text-outline-primary: var(--pgn-color-primary-500);
   --pgn-color-btn-active-text-tertiary: var(--pgn-color-primary-500);
   --pgn-color-btn-active-bg-brand: var(--pgn-color-brand-500);
+  --pgn-color-btn-active-bg-inverse-brand: var(--pgn-color-brand-500);
   --pgn-color-btn-active-bg-danger: var(--pgn-color-theme-active-danger);
   --pgn-color-btn-active-bg-outline-danger: var(--pgn-color-btn-bg-danger);
   --pgn-color-btn-active-bg-dark: var(--pgn-color-theme-active-dark);
@@ -486,6 +495,7 @@
   --pgn-color-theme-active-secondary: var(--pgn-color-secondary-900); /** Theme-specific secondary active color. */
   --pgn-color-btn-text-brand: #FFFFFFFF;
   --pgn-color-btn-text-outline-brand: var(--pgn-color-btn-bg-brand);
+  --pgn-color-btn-text-inverse-brand: #FFFFFFFF;
   --pgn-color-btn-text-light: #454545FF;
   --pgn-color-btn-text-outline-light: var(--pgn-color-btn-bg-light);
   --pgn-color-btn-bg-secondary: var(--pgn-color-secondary-600);
@@ -605,11 +615,13 @@
   --pgn-color-btn-focus-bg-secondary: var(--pgn-color-btn-bg-secondary);
   --pgn-color-btn-focus-outline-brand: var(--pgn-color-btn-border-brand);
   --pgn-color-btn-focus-outline-outline-brand: var(--pgn-color-btn-border-outline-brand);
+  --pgn-color-btn-focus-outline-inverse-brand: var(--pgn-color-btn-border-brand);
   --pgn-color-btn-focus-outline-light: var(--pgn-color-btn-border-light);
   --pgn-color-btn-focus-outline-outline-light: var(--pgn-color-btn-border-outline-light);
   --pgn-color-btn-focus-outline-primary: var(--pgn-color-btn-border-primary);
   --pgn-color-btn-focus-outline-outline-primary: var(--pgn-color-btn-border-outline-primary);
   --pgn-color-btn-disabled-text-brand: var(--pgn-color-btn-text-brand);
+  --pgn-color-btn-disabled-text-inverse-brand: var(--pgn-color-btn-text-inverse-brand);
   --pgn-color-btn-disabled-text-outline-brand: var(--pgn-color-btn-text-outline-brand);
   --pgn-color-btn-disabled-text-light: var(--pgn-color-btn-text-light);
   --pgn-color-btn-disabled-text-outline-secondary: var(--pgn-color-btn-hover-text-outline-secondary);

--- a/paragon/css/themes/light/variables.css
+++ b/paragon/css/themes/light/variables.css
@@ -211,7 +211,7 @@
   --pgn-color-btn-hover-text-outline-success: #FFFFFFFF;
   --pgn-color-btn-hover-text-outline-warning: #393939FF;
   --pgn-color-btn-hover-bg-brand: var(--pgn-color-white);
-  --pgn-color-btn-hover-bg-inverse-brand: #ECECECFF;
+  --pgn-color-btn-hover-bg-inverse-brand: var(--pgn-color-white);
   --pgn-color-btn-hover-bg-outline-danger: var(--pgn-color-danger-600);
   --pgn-color-btn-hover-bg-outline-dark: var(--pgn-color-dark-600);
   --pgn-color-btn-hover-bg-outline-info: var(--pgn-color-info-600);

--- a/tokens/src/themes/light/components/Button/brand.json
+++ b/tokens/src/themes/light/components/Button/brand.json
@@ -6,16 +6,17 @@
           "$value": "{color.btn.bg.brand}",
           "$type": "color",
           "source": "$btn-brand-color",
-          "modify": [
-            {
-              "type": "color-yiq"
-            }
-          ]
+          "modify": [{ "type": "color-yiq" }]
         },
         "outline-brand": {
           "$value": "{color.btn.bg.brand}",
           "$type": "color",
           "source": "$btn-brand-outline-color"
+        },
+        "inverse-brand": {
+          "$value": "{color.btn.bg.inverse-brand}",
+          "$type": "color",
+          "modify": [{ "type": "color-yiq" }]
         }
       },
       "bg": {
@@ -28,6 +29,11 @@
           "$value": "{color.white}",
           "$type": "color",
           "source": "$btn-brand-outline-bg"
+        },
+        "inverse-brand": {
+          "$value": "{color.brand.500}",
+          "$type": "color",
+          "modify": null
         }
       },
       "border": {
@@ -55,6 +61,11 @@
             "$type": "color",
             "source": "$btn-brand-outline-hover-color",
             "modify": null
+          },
+          "inverse-brand": {
+            "$value": "{color.brand.500}",
+            "$type": "color",
+            "modify": null
           }
         },
         "bg": {
@@ -67,6 +78,10 @@
             "$value": "{color.brand.500}",
             "$type": "color",
             "source": "$btn-brand-outline-hover-bg"
+          },
+          "inverse-brand": {
+            "$value": "{color.white}",
+            "$type": "color"
           }
         },
         "border": {
@@ -79,6 +94,11 @@
             "$value": "{color.btn.hover.bg.outline-brand}",
             "$type": "color",
             "source": "$btn-brand-outline-hover-border-color"
+          },
+          "inverse-brand": {
+            "$value": "{color.brand.500}",
+            "$type": "color",
+            "modify": null
           }
         }
       },
@@ -95,6 +115,11 @@
             "$type": "color",
             "source": "$btn-brand-outline-active-color",
             "modify": null
+          },
+          "inverse-brand": {
+            "$value": "{color.white}",
+            "$type": "color",
+            "modify": null
           }
         },
         "bg": {
@@ -107,6 +132,10 @@
             "$value": "{color.white}",
             "$type": "color",
             "source": "$btn-brand-outline-active-bg"
+          },
+          "inverse-brand": {
+            "$value": "{color.brand.500}",
+            "$type": "color"
           }
         },
         "border": {
@@ -127,8 +156,7 @@
           "brand": {
             "$value": "{color.white}",
             "$type": "color",
-            "source": "$btn-brand-focus-color",
-            "modify": null
+            "source": "$btn-brand-focus-color"
           },
           "outline-brand": {
             "$value": "{color.brand.500}",
@@ -146,6 +174,10 @@
             "$value": "{color.btn.border.outline-brand}",
             "$type": "color",
             "source": "$btn-brand-outline-focus-border-color"
+          },
+          "inverse-brand": {
+            "$value": "{color.btn.border.inverse-brand}",
+            "$type": "color"
           }
         },
         "outline": {
@@ -158,6 +190,10 @@
             "$value": "{color.btn.border.outline-brand}",
             "$type": "color",
             "source": "$btn-brand-outline-focus-outline-color"
+          },
+          "inverse-brand": {
+            "$value": "{color.btn.border.brand}",
+            "$type": "color"
           }
         },
         "bg": {
@@ -184,6 +220,10 @@
             "$value": "{color.btn.text.outline-brand}",
             "$type": "color",
             "source": "$btn-brand-outline-disabled-color"
+          },
+          "inverse-brand": {
+            "$value": "{color.btn.text.inverse-brand}",
+            "$type": "color"
           }
         },
         "bg": {
@@ -196,6 +236,10 @@
             "$value": "{color.white}",
             "$type": "color",
             "source": "$btn-brand-outline-disabled-bg"
+          },
+          "inverse-brand": {
+            "$value": "{color.brand.100}",
+            "$type": "color"
           }
         },
         "border": {

--- a/tokens/src/themes/light/components/Button/brand.json
+++ b/tokens/src/themes/light/components/Button/brand.json
@@ -99,7 +99,8 @@
           },
           "inverse-brand": {
             "$value": "{color.white}",
-            "$type": "color"
+            "$type": "color",
+            "modify": null
           },
           "inverse-outline-brand": {
             "$value": "{color.brand.500}",

--- a/tokens/src/themes/light/components/Button/brand.json
+++ b/tokens/src/themes/light/components/Button/brand.json
@@ -17,6 +17,11 @@
           "$value": "{color.btn.bg.inverse-brand}",
           "$type": "color",
           "modify": [{ "type": "color-yiq" }]
+        },
+        "inverse-outline-brand": {
+          "$value": "{color.brand.500}",
+          "$type": "color",
+          "modify": null
         }
       },
       "bg": {
@@ -34,6 +39,10 @@
           "$value": "{color.brand.500}",
           "$type": "color",
           "modify": null
+        },
+        "inverse-outline-brand": {
+          "$value": "{color.white}",
+          "$type": "color"
         }
       },
       "border": {
@@ -46,6 +55,10 @@
           "$value": "{color.btn.bg.brand}",
           "$type": "color",
           "source": "$btn-brand-outline-border-color"
+        },
+        "inverse-outline-brand": {
+          "$value": "{color.brand.500}",
+          "$type": "color"
         }
       },
       "hover": {
@@ -66,6 +79,11 @@
             "$value": "{color.brand.500}",
             "$type": "color",
             "modify": null
+          },
+          "inverse-outline-brand": {
+            "$value": "{color.white}",
+            "$type": "color",
+            "modify": null
           }
         },
         "bg": {
@@ -82,6 +100,11 @@
           "inverse-brand": {
             "$value": "{color.white}",
             "$type": "color"
+          },
+          "inverse-outline-brand": {
+            "$value": "{color.brand.500}",
+            "$type": "color",
+            "modify": null
           }
         },
         "border": {
@@ -99,6 +122,10 @@
             "$value": "{color.brand.500}",
             "$type": "color",
             "modify": null
+          },
+          "inverse-outline-brand": {
+            "$value": "{color.btn.hover.bg.outline-brand}",
+            "$type": "color"
           }
         }
       },
@@ -120,6 +147,11 @@
             "$value": "{color.white}",
             "$type": "color",
             "modify": null
+          },
+          "inverse-outline-brand": {
+            "$value": "{color.white}",
+            "$type": "color",
+            "modify": null
           }
         },
         "bg": {
@@ -134,6 +166,10 @@
             "source": "$btn-brand-outline-active-bg"
           },
           "inverse-brand": {
+            "$value": "{color.brand.500}",
+            "$type": "color"
+          },
+          "inverse-outline-brand": {
             "$value": "{color.brand.500}",
             "$type": "color"
           }
@@ -206,6 +242,10 @@
             "$value": "{color.btn.bg.outline-brand}",
             "$type": "color",
             "source": "$btn-brand-outline-focus-bg"
+          },
+          "inverse-outline-brand": {
+            "$value": "{color.white}",
+            "$type": "color"
           }
         }
       },


### PR DESCRIPTION
## Figma

[Figma](https://www.figma.com/design/I7OtSoBzgms4GxDXfzw0pW/Paragon-Elm-Theme?node-id=56500-911&t=RJTpsM59HzopZRJc-4)

<img width="746" alt="image" src="https://github.com/user-attachments/assets/6c16b3d9-9a60-42bf-92d5-16d3c95d3521" />

## Docs site preview

### Default

<img width="626" alt="image" src="https://github.com/user-attachments/assets/ae1de450-ea3a-4c60-99b6-1f7e935a40ca" />

### Hover

<img width="632" alt="image" src="https://github.com/user-attachments/assets/d10afb67-9b0e-4897-9cce-f92c5debaec2" />

### Focus

<img width="637" alt="image" src="https://github.com/user-attachments/assets/97b8388e-af0f-427e-9b99-abcb959d602a" />

### Disabled

<img width="644" alt="image" src="https://github.com/user-attachments/assets/694a7040-8a39-4fbe-884b-8da00467c9b5" />

### Active (not depicted in Figma)

<img width="629" alt="image" src="https://github.com/user-attachments/assets/24312b55-38a1-47e8-8011-cf2f3f9f9a4c" />
