### PR TITLE
feat: integrate Paragon CLI serve-theme-css and update README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -115,6 +115,19 @@ This package uses design tokens to define the Elm theme's visual system. These t
 
 The design tokens include colors, typography, spacing, and component styles that follow the Elm brand identity. They're defined as JSON files in the ``tokens/src`` directory and compiled into CSS custom properties following the pattern ``--pgn-*``.
 
+**Token Structure**
+
+The design tokens are organized in the following structure:
+
+- ``tokens/src/core/`` - Core tokens (typography, spacing, global utilities)
+- ``tokens/src/themes/light/`` - Light theme-specific tokens
+  - ``global/`` - Global theme tokens (colors, elevation, etc.)
+  - ``components/`` - Component-specific tokens (Button, Card, etc.)
+
+**Token Properties**
+
+Some tokens have ``"modify": null`` property specified to disable default Paragon behavior that modifies specific tokens during build time. This is used when you want to preserve exact token values without Paragon's automatic modifications.
+
 For detailed information about the available design tokens and how to use them, see the `tokens/` directory in this repository and the Paragon design system documentation.
 
 -------------
@@ -137,8 +150,6 @@ The package provides both regular and minified CSS files:
 When using the Paragon CLI's ``build-tokens`` command, the package generates a ``theme-urls.json`` file that defines the available theme files. Consuming applications can automatically inject these CSS files based on this configuration.
 
 The Elm theme overrides Paragon's default design tokens to apply the Elm brand identity. These overrides are defined in the ``tokens/src`` directory and follow the same structure as Paragon's token system.
-
-Some tokens have ``"modify": null`` property specified to disable default Paragon behavior that modifies specific tokens during build time.
 
 -----
 Development
@@ -173,7 +184,7 @@ Set up the project for development:
 
 **Making Changes**
 
-#. **Start Development Servers**: Run these in separate terminal windows:
+#. **Start Development Environment**: Run these in separate terminal windows
     * ``npm run build:watch`` - Watches for token changes and rebuilds CSS
     * ``npm run serve-theme-css`` - Serves the theme CSS for preview
 #. **Update Design Tokens**: Modify JSON files in ``tokens/src/``

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,9 @@
 @edx/elm-theme
 ==================
 
-This project contains elm-theme branding assets and design tokens for edx.org. It is the edX implementation of the branding interface defined in `@edx/brand-openedx <https://git@github.com/edx/brand-openedx>`_. Note that we aim to avoid introducing any breaking changes.
+This project contains elm-theme branding assets and design tokens for edx.org. It is the edX implementation of the branding interface defined in `@edx/brand-openedx <https://git@github.com/edx/brand-openedx>`_. 
+
+This package provides design token overrides for Paragon v23+ and does not implement components on its own. It is intended to be used in conjunction with Paragon to apply the Elm brand identity to Paragon components and design tokens.
 
 -----
 Usage

--- a/README.rst
+++ b/README.rst
@@ -2,38 +2,39 @@
 @edx/elm-theme
 ==================
 
-This project contains elm-theme branding assets and styles for edx.  It can be used to ensure that a project coheres to the elm visual style.  
-
-It uses `design tokens <https://github.com/amzn/style-dictionary>`_ to define colors, spacing, typography, and other fundamental styles. These tokens get compiled into css classes that are exposed through the npm package.  Users can reference these classes in their projects.
-
-Elm-theme can be used alone or in conjunction with paragon.  Because paragon is a dependency, elm-theme already contains all core paragon css classes.  It just overrides certain classes with elm-theme styles.  However elm-theme on its own does not give users the ability to use paragon components. 
-
-Elm-theme shouldn't be used with other themes (like the `edx-brand <https://github.com/edx/brand-edx.org>`_ theme).
+This project contains elm-theme branding assets and design tokens for edx.org. It is the edX implementation of the branding interface defined in `@edx/brand-openedx <https://git@github.com/edx/brand-openedx>`_. Note that we aim to avoid introducing any breaking changes.
 
 -----
 Usage
 -----
 
-Install this package one of two ways:
-
-
-Versioned with npm. Including this project this way will allow you to control the version you pull into your application. This is safer, but it also means you will need to manually update it or use some automation to update it for you.
+Install this package:
 
 .. code-block:: bash
 
-  npm install --save @edx/elm-theme@npm:@edx/elm-theme
+  npm install --save @edx/brand@npm:@edx/elm-theme
 
-Unversioned with Github. Including this project this way will pull in the latest version of it whenever a project's requirements are installed. This alleviates the need to manually pull in updates. The draw back is that if a breaking change is inadvertently introduced it is likely to gum up your pipeline or create a visual bug.
+Import the theme and assets:
 
-.. code-block:: bash
+.. code-block:: css
 
-  npm install --save @edx/elm-theme@git+https://git@github.com/edx/elm-theme#main
+  // Import pre-built CSS with design tokens via CSS variables
 
-Import assets from this package in a consuming node application:
+  @import '@edx/brand/dist/core.css'; // Core theme CSS
+  @import '@edx/brand/dist/core.min.css'; // Core theme CSS (minified)
+  @import '@edx/brand/dist/light.css'; // Light theme CSS
+  @import '@edx/brand/dist/light.min.css'; // Light theme CSS (minified)
 
 .. code-block:: javascript
 
-  import logo from '@edx/elm-theme/logo.svg';
+  // Import brand assets
+  import logo from '@edx/brand/logo.svg';
+
+**Open edX Micro-frontend Integration**
+
+When using this package with Open edX micro-frontends (MFEs), you do not need to import the CSS files directly. The CSS files from the ``@edx/brand`` NPM alias will be automatically injected at runtime by ``@edx/frontend-platform``.
+
+Install the package at build time and the theme will be applied automatically.
 
 --------------
 Images & Logos
@@ -48,10 +49,10 @@ edX Logo
 
 .. code-block:: javascript
 
-  import logo from '@edx/elm-theme/logo.svg';
+  import logo from '@edx/brand/logo.svg';
 
   // Or the png version
-  import logo from '@edx/elm-theme/logo.png';
+  import logo from '@edx/brand/logo.png';
 
 edX Logo with ®
 ---------------
@@ -62,10 +63,10 @@ edX Logo with ®
 
 .. code-block:: javascript
 
-  import logo from '@edx/elm-theme/logo-trademark.svg';
+  import logo from '@edx/brand/logo-trademark.svg';
 
   // Or the png version
-  import logo from '@edx/elm-theme/logo-trademark.png';
+  import logo from '@edx/brand/logo-trademark.png';
 
 edX Logo in white
 -----------------
@@ -76,10 +77,10 @@ edX Logo in white
 
 .. code-block:: javascript
 
-  import logo from '@edx/elm-theme/logo-white.svg';
+  import logo from '@edx/brand/logo-white.svg';
 
   // Or the png version
-  import logo from '@edx/elm-theme/logo-white.png';
+  import logo from '@edx/brand/logo-white.png';
 
 edX Favicon
 -----------------
@@ -90,7 +91,7 @@ edX Favicon
 
 .. code-block:: javascript
 
-  // @edx/elm-theme/favicon.ico;
+  // @edx/brand/favicon.ico;
 
 Default fallback image for `Card.ImageCap` component
 --------
@@ -102,54 +103,104 @@ Default fallback image for `Card.ImageCap` component
 .. code-block:: javascript
 
   // the png version
-  import cardFallbackImg from '@edx/elm-theme/paragon/images/card-imagecap-fallback.png';
+  import cardFallbackImg from '@edx/brand/paragon/images/card-imagecap-fallback.png';
 
----------------------------------
-Including Elm Styles in a Project
----------------------------------
+-------------
+Design Tokens
+-------------
 
-You can use the theme in two ways:
+This package uses design tokens to define the Elm theme's visual system. These tokens are compiled into CSS custom properties that can be used throughout your application.
 
-1. this repo builds and publishes its own CSS files (located in the `dist` directory) by including and overriding Paragon's styles,
-   so you can just inject them into your application **without** needing to import / compile Paragon's style separately
-2. compile the styles on your own in your application - override paragon defaults with elm styles
+The design tokens include colors, typography, spacing, and component styles that follow the Elm brand identity. They're defined as JSON files in the ``tokens/src`` directory and compiled into CSS custom properties following the pattern ``--pgn-*``.
 
-  .. code-block:: sass
+For detailed information about the available design tokens and how to use them, see the `tokens/` directory in this repository and the Paragon design system documentation.
 
-    @import '@edx/elm-theme/paragon/fonts.scss';
-    @import '@edx/elm-theme/paragon/variables.scss';
-    @import '@openedx/paragon/scss/core/core.scss';
-    @import '@edx/elm-theme/paragon/overrides.scss';
+-------------
+Paragon Theme
+-------------
 
+Use the theme in this package as described in the Paragon docs: https://paragon-openedx.netlify.app/
 
--------------------------------------
-Theming with Paragon's Design Tokens
--------------------------------------
-Starting from `v21` Paragon uses style-dictionary to build CSS variables from design tokens (i.e. JSON files), Paragon
-allows to override design tokens values before building CSS variables allowing to apply custom theme.
+**Available CSS Files**
 
-See `tokens` directory for tokens that the elm theme overrides. This directory should follow the same folder/JSON structure as is used on whatever version of Paragon is installed in this repository. These JSON files are deep-merged with the default/standard Paragon design tokens.
-Note that some tokens have `"modify": null` property specified, this is done to disable default Paragon's behaviour that modifies this specific token in some way, read more about token's modifications during build time here[TODO: add link to Paragon readme].
+The package provides both regular and minified CSS files:
 
-Building design tokens
-#############################
+- ``dist/core.css`` - Core theme CSS with design tokens
+- ``dist/core.min.css`` - Core theme CSS (minified)
+- ``dist/light.css`` - Light theme CSS with design tokens
+- ``dist/light.min.css`` - Light theme CSS (minified)
 
-#. Install Paragon with
+**Automatic Theme Injection**
 
-   .. code-block:: bash
+When using the Paragon CLI's ``build-tokens`` command, the package generates a ``theme-urls.json`` file that defines the available theme files. Consuming applications can automatically inject these CSS files based on this configuration.
 
-     npm install
+The Elm theme overrides Paragon's default design tokens to apply the Elm brand identity. These overrides are defined in the ``tokens/src`` directory and follow the same structure as Paragon's token system.
 
-#. Update values in `tokens` folder
-#. Run following command to build updated CSS files with CSS variables (they are located in `paragon/css` directory)
+Some tokens have ``"modify": null`` property specified to disable default Paragon behavior that modifies specific tokens during build time.
 
-   .. code-block:: bash
+-----
+Development
+-----
 
-     npm run build-tokens
+**Local Development**
+
+Set up the project for development:
+
+.. code-block:: bash
+
+  # Clone the repository
+  git clone https://github.com/edx/elm-theme.git
+  cd elm-theme
+
+  # Install dependencies
+  npm install
+
+  # Build the theme
+  npm run build
+
+  # Watch for changes during development
+  npm run build:watch
+
+**Available Scripts**
+
+- ``npm run build-tokens`` - Build CSS from design tokens
+- ``npm run build-scss`` - Build SASS files
+- ``npm run build`` - Complete build process
+- ``npm run build:watch`` - Watch mode for development
+- ``npm run serve-theme-css`` - Serve theme CSS for testing
+
+**Making Changes**
+
+1. **Start Development Servers**: Run these in separate terminal windows:
+   - ``npm run build:watch`` - Watches for token changes and rebuilds CSS
+   - ``npm run serve-theme-css`` - Serves the theme CSS for preview
+2. **Update Design Tokens**: Modify JSON files in ``tokens/src/``
+3. **Preview Changes**: View changes at the provided Paragon docs URL with the local theme applied.
+
+**File Structure**
+
+.. code-block:: text
+
+  elm-theme/
+  ├── tokens/src/           # Design token definitions
+  │   ├── core/            # Core tokens (typography, spacing)
+  │   └── themes/          # Theme-specific tokens
+  ├── paragon/             # Generated CSS files and overrides
+  │   ├── css/            # Generated CSS files with design tokens
+  ├── dist/               # Built CSS for distribution
+  │   ├── core.css        # Core theme CSS with design tokens
+  │   ├── core.min.css    # Core theme CSS (minified)
+  │   ├── light.css       # Light theme CSS with design tokens
+  │   ├── light.min.css   # Light theme CSS (minified)
+  │   └── theme-urls.json # Theme configuration for automatic injection
+  └── logo.*             # Brand assets
+
 
 
 --------------------------------
 Publishing with Semantic Release
 --------------------------------
 
-This project is published to npm with Semantic Release. When a pull request is merged to main Semantic Release reads the commit messages to determine whether to make a new patch. minor, or major release of this package. For more info see https://github.com/semantic-release/semantic-release#how-does-it-work
+This project is published to npm with Semantic Release. When a pull request is merged to main, Semantic Release reads the commit messages to determine whether to make a new patch, minor, or major release of this package.
+
+For more information about Semantic Release, see https://github.com/semantic-release/semantic-release#how-does-it-work

--- a/README.rst
+++ b/README.rst
@@ -173,11 +173,11 @@ Set up the project for development:
 
 **Making Changes**
 
-1. **Start Development Servers**: Run these in separate terminal windows:
-   - ``npm run build:watch`` - Watches for token changes and rebuilds CSS
-   - ``npm run serve-theme-css`` - Serves the theme CSS for preview
-2. **Update Design Tokens**: Modify JSON files in ``tokens/src/``
-3. **Preview Changes**: View changes at the provided Paragon docs URL with the local theme applied.
+#. **Start Development Servers**: Run these in separate terminal windows:
+    * ``npm run build:watch`` - Watches for token changes and rebuilds CSS
+    * ``npm run serve-theme-css`` - Serves the theme CSS for preview
+#. **Update Design Tokens**: Modify JSON files in ``tokens/src/``
+#. **Preview Changes**: View changes at the provided Paragon docs URL with the local theme applied.
 
 **File Structure**
 

--- a/README.rst
+++ b/README.rst
@@ -180,7 +180,7 @@ Set up the project for development:
 - ``npm run build-scss`` - Build SASS files
 - ``npm run build`` - Complete build process
 - ``npm run build:watch`` - Watch mode for development
-- ``npm run serve-theme-css`` - Serve theme CSS for testing
+- ``npm run serve-theme-css`` - Serve theme CSS for testing and generate Paragon docs URL
 
 **Making Changes**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "UNLICENSED",
       "devDependencies": {
-        "@openedx/paragon": "^23.13.0",
+        "@openedx/paragon": "^23.14.0",
         "nodemon": "^3.1.4"
       }
     },
@@ -550,9 +550,9 @@
       }
     },
     "node_modules/@openedx/paragon": {
-      "version": "23.13.0",
-      "resolved": "https://registry.npmjs.org/@openedx/paragon/-/paragon-23.13.0.tgz",
-      "integrity": "sha512-lVviyJspbpVhO9oWcKK1s52nICWnWXShm2e+fGQCBmkGrPhPYt0iT9PAEiMmGLPy8oGX/HHC85ot35+yia708w==",
+      "version": "23.14.0",
+      "resolved": "https://registry.npmjs.org/@openedx/paragon/-/paragon-23.14.0.tgz",
+      "integrity": "sha512-+z5PspPI5D+/Xh87KG0ZYt/E+mOlgEMj6/IXeBWSj0vUvawj/pYzKgj+hlGbFGV9lIKkKnQJA8iurQrR++VXZA==",
       "dev": true,
       "license": "Apache-2.0",
       "workspaces": [
@@ -580,6 +580,7 @@
         "js-toml": "^1.0.0",
         "lodash.uniqby": "^4.7.0",
         "log-update": "^4.0.0",
+        "lz-string": "^1.5.0",
         "mailto-link": "^2.0.0",
         "minimist": "^1.2.8",
         "ora": "^5.4.1",
@@ -2406,6 +2407,16 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
     },
     "node_modules/mailto-link": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -20,10 +20,11 @@
     "build-scss": "paragon build-scss --corePath ./paragon/core.scss --themesPath ./paragon/css/themes --defaultThemeVariants light",
     "build": "make build",
     "build:watch": "nodemon --ignore dist -x \"make build\"",
+    "serve-theme-css": "paragon serve-theme-css --theme-name 'Local Elm (edX.org)'",
     "paragon:help": "paragon help"
   },
   "devDependencies": {
-    "@openedx/paragon": "^23.13.0",
+    "@openedx/paragon": "^23.14.0",
     "nodemon": "^3.1.4"
   }
 }


### PR DESCRIPTION
1. Integrates with the recently added [Paragon CLI command `serve-theme-css`](https://github.com/openedx/paragon/pull/3679) to improve the development experience when making changes to this Elm theme.
2. Updates the README with more relevant information ([formatted preview](https://github.com/edx/elm-theme/blob/8641b0c230a4c26278944d079f8ad03deeedd4d4/README.rst)).