### PR TITLE
fix: badge padding and info badge color

### DIFF
--- a/paragon/css/core/variables.css
+++ b/paragon/css/core/variables.css
@@ -17,8 +17,6 @@
   --pgn-size-popover-border-width: 0px;
   --pgn-size-caret-width: 0.3em;
   --pgn-size-input-btn-border-width: 1px;
-  --pgn-spacing-badge-padding-x-base: 0.5rem;
-  --pgn-spacing-badge-padding-x-pill: 0.6rem;
   --pgn-spacing-badge-padding-y: 0.5rem;
   --pgn-spacing-btn-focus-gap: 2px;
   --pgn-spacing-spacer-0: 0; /** Space value of level 0 */

--- a/paragon/css/core/variables.css
+++ b/paragon/css/core/variables.css
@@ -17,6 +17,9 @@
   --pgn-size-popover-border-width: 0px;
   --pgn-size-caret-width: 0.3em;
   --pgn-size-input-btn-border-width: 1px;
+  --pgn-spacing-badge-padding-x-base: 0.5rem;
+  --pgn-spacing-badge-padding-x-pill: 0.6rem;
+  --pgn-spacing-badge-padding-y: 0.5rem;
   --pgn-spacing-btn-focus-gap: 2px;
   --pgn-spacing-spacer-0: 0; /** Space value of level 0 */
   --pgn-spacing-spacer-base: 1rem; /** Basic space value */

--- a/paragon/css/themes/light/variables.css
+++ b/paragon/css/themes/light/variables.css
@@ -184,7 +184,6 @@
   --pgn-color-theme-active-light: var(--pgn-color-light-900); /** Theme-specific light active color. */
   --pgn-color-theme-active-dark: var(--pgn-color-dark-900); /** Theme-specific dark active color. */
   --pgn-color-theme-active-gray: var(--pgn-color-gray-900); /** Theme-specific gray active color. */
-  --pgn-color-badge-bg-info: var(--pgn-color-accent-a);
   --pgn-color-btn-text-primary: var(--pgn-color-white);
   --pgn-color-btn-bg-outline-brand: var(--pgn-color-white);
   --pgn-color-btn-bg-inverse-outline-brand: var(--pgn-color-white);

--- a/tokens/src/core/components/Badge.json
+++ b/tokens/src/core/components/Badge.json
@@ -1,4 +1,16 @@
 {
+  "spacing": {
+    "$type": "dimension",
+    "badge": {
+      "padding": {
+        "x": {
+          "base": { "source": "$badge-padding-x", "$value": ".5rem" },
+          "pill": { "source": "$badge-pill-padding-x", "$value": ".6rem" }
+        },
+        "y": { "source": "$badge-padding-y", "$value": ".5rem" }
+      }
+    }
+  },
   "typography": {
     "badge": {
       "font": {

--- a/tokens/src/core/components/Badge.json
+++ b/tokens/src/core/components/Badge.json
@@ -3,10 +3,6 @@
     "$type": "dimension",
     "badge": {
       "padding": {
-        "x": {
-          "base": { "source": "$badge-padding-x", "$value": ".5rem" },
-          "pill": { "source": "$badge-pill-padding-x", "$value": ".6rem" }
-        },
         "y": { "source": "$badge-padding-y", "$value": ".5rem" }
       }
     }

--- a/tokens/src/themes/light/components/Badge.json
+++ b/tokens/src/themes/light/components/Badge.json
@@ -1,9 +1,0 @@
-{
-  "color": {
-    "badge": {
-      "bg": {
-        "info": { "$value": "{color.accent.a}" }
-      }
-    }
-  }
-}


### PR DESCRIPTION
This PR adds some padding to the top and bottom of the Badge component to better match the mock up in the [Elm theme Figma file](https://www.figma.com/design/I7OtSoBzgms4GxDXfzw0pW/Paragon-Elm-Theme?node-id=14045-58&m=dev). Also included is a modification to the color used for the `Info` Badge. It now defaults to the `Info` color (used in Alerts and elsewhere in Paragon) rather than the `accent-b` color.

Previous Badge with tight padding on top/bottom and different color for `Info`:
<img width="523" height="49" alt="Screenshot 2025-08-13 at 1 31 03 PM" src="https://github.com/user-attachments/assets/c9a4d145-e892-4569-beaa-25d5fa9a3bcd" />

New Badge with adjusted padding and Info badge color:
<img width="523" height="59" alt="Screenshot 2025-08-13 at 1 28 26 PM" src="https://github.com/user-attachments/assets/b7360942-a749-46c6-a146-7d07a73e790e" />

### How to test locally

The easiest way to test this is by using the CLI command to serve the styles locally and then have the Paragon doc site use those local styles as it's current theme. The command does pretty much all of the work for us.

#### Steps

1. Pull down this branch
2. Run `npm ci`
3. Run `npm run serve-theme-css`
4. This will spit out a URL in the terminal for the Paragon doc site with a long query string
<img width="1086" height="470" alt="Screenshot 2025-08-14 at 1 58 11 PM" src="https://github.com/user-attachments/assets/3fb4bc86-b55a-40bf-bcaa-ac0b016c2af7" />

5. Go to that URL and you should see the local styles being used as the theme
6. To verify this, click the side panel on the left and check what the theme is set to:
<img width="1318" height="472" alt="Screenshot 2025-08-14 at 1 58 44 PM" src="https://github.com/user-attachments/assets/9d5e4886-f3ce-4684-9451-a888ea6e1110" />

7. Click the dropdown for the theme
<img width="461" height="386" alt="Screenshot 2025-08-14 at 2 00 09 PM" src="https://github.com/user-attachments/assets/e3eceff6-cd9e-4572-bbc5-9698faafc860" />

8. Click edit and you should see a modal pop up with the local styles being references at localhost:3000
<img width="1316" height="644" alt="Screenshot 2025-08-14 at 1 59 38 PM" src="https://github.com/user-attachments/assets/5ad14936-2f00-4aa4-9622-d25ffda3f5c2" />

9. Finally, go to the page for the Badge component (can use search bar in top left if needed) and verify that the styles look the same as they do [in the Figma](https://www.figma.com/design/I7OtSoBzgms4GxDXfzw0pW/Paragon-Elm-Theme?node-id=14045-58&m=dev). NOTE, the color for Info Badge in the Figma is not the same. However, the color used in the Figma is not in our color palette so we are just defaulting to the base `Info` color (which we know is accessible)
